### PR TITLE
Fixed scientific exponent handling

### DIFF
--- a/Grammar/NCalc.g
+++ b/Grammar/NCalc.g
@@ -251,7 +251,8 @@ INTEGER
 	;
 
 FLOAT 
-	:	DIGIT* '.' DIGIT+ E?
+	:	DIGIT+ '.' DIGIT* E?
+	|	'.' DIGIT+ E?
 	|	DIGIT+ E
 	;
 
@@ -266,7 +267,8 @@ DATETIME
 NAME	:	'[' (options {greedy=false;} : ~(']')*) ']'
 	;
 	
-E	:	('E'|'e') ('+'|'-')? DIGIT+ 
+fragment E
+	:	('E'|'e') ('+'|'-')? DIGIT+ 
 	;	
 	
 fragment LETTER


### PR DESCRIPTION
Fixed NCalc handling of scientific exponent (E) which caused an E parameter not to work. This was an issue reported in CodePlex
Improved format for floating point values
The Lexer and parser need to be rebuilt